### PR TITLE
Fixed license issue. Create output directory if it was missing. Replace base classes on copy.

### DIFF
--- a/src/Generator/CGTKClassWriter.m
+++ b/src/Generator/CGTKClassWriter.m
@@ -39,6 +39,16 @@
 {
 	NSError *error = nil;
 	
+	BOOL isDir;
+	NSFileManager *fileManager= [NSFileManager defaultManager]; 
+	if(![fileManager fileExistsAtPath:outputDir isDirectory:&isDir])
+	{
+		if(![fileManager createDirectoryAtPath:outputDir withIntermediateDirectories:YES attributes:nil error:NULL])
+		{
+		    NSLog(@"Error creating output directory: %@", outputDir);
+		}
+	}
+	
 	// Header
 	NSString *hFilename = [[outputDir stringByAppendingPathComponent:[cgtkClass name]] stringByAppendingPathExtension:@"h"];
 		
@@ -280,7 +290,7 @@
 +(NSString *)generateLicense:(NSString *)fileName
 {
 	NSError *error = nil;
-	NSString *licText = [NSString stringWithContentsOfFile:@"conf/license.txt" encoding:NSStringEncodingConversionAllowLossy error:&error];
+	NSString *licText = [NSString stringWithContentsOfFile:@"Config/license.txt" encoding:NSStringEncodingConversionAllowLossy error:&error];
 	
 	if(error == nil)
 	{

--- a/src/main.m
+++ b/src/main.m
@@ -110,17 +110,20 @@ int main(int argc, char *argv[])
 
 						if([fileMgr fileExistsAtPath:dest])
 						{
-							NSLog(@"File [%@] already exists in destination [%@]", src, dest);
-						}
-						else
-						{
-							NSLog(@"Copying file [%@] to [%@]...", src, dest);
-							if(![fileMgr copyItemAtPath:src
-												    toPath:dest
-												     error:&error])
+							NSLog(@"File [%@] already exists in destination [%@]. Removing existing file...", src, dest);
+							if(![fileMgr removeItemAtPath:dest error:&error])
 							{
-								NSLog(@"Error: %@", error);
+								NSLog(@"Error removing file [%@]: %@. Skipping file.", dest, error);
+								continue;
 							}
+						}
+						
+						NSLog(@"Copying file [%@] to [%@]...", src, dest);
+						if(![fileMgr copyItemAtPath:src
+											    toPath:dest
+											     error:&error])
+						{
+							NSLog(@"Error: %@", error);
 						}
 					}
 				}


### PR DESCRIPTION
- Fixed license directory issue.
- Added code to create Output directory if it was missing.
- Replace existing base classes while copying so we always get the most recent version.
